### PR TITLE
Use main branch of python-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/platformatic/python#readme",
   "dependencies": {
     "@fastify/static": "^8.2.0",
-    "@platformatic/python-node": "github:platformatic/python-node#test-improvements",
+    "@platformatic/python-node": "github:platformatic/python-node",
     "@platformatic/service": "^2.63.3",
     "json-schema-to-typescript": "^15.0.4"
   },


### PR DESCRIPTION
Just switching to use the main branch now that the improvements PR has landed. I'll switch this to use the proper released version soon though, once I get the publish flow worked out.